### PR TITLE
Import React correctly

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,11 +1,5 @@
-import React, {
-  forwardRef,
-  memo,
-  useCallback,
-  useEffect,
-  useRef,
-  useState
-} from "react";
+import React from "react";
+const { forwardRef, memo, useCallback, useEffect, useRef, useState } = React;
 
 /**
  * ReactStickyNav assumes that its container has `position: sticky;`


### PR DESCRIPTION
React is a CommonJS-only module, so `import { foo, bar } from 'react'` is invalid. Specifically, it causes problems when doing SSR via webpack. See [nodejs documentation](https://nodejs.org/dist/latest-v12.x/docs/api/esm.html#esm_import_statements) for details on why this import is invalid.

The original problem I have is here: https://github.com/gatsbyjs/gatsby/issues/22599#issuecomment-605150829 for details.